### PR TITLE
Dockerfile: Update branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV NGINX_MAX_UPLOAD 1M
 ENV UWSGI_CHEAPER 0
 ENV UWSGI_PROCESSES 1
 
-RUN pip install --no-cache-dir git+https://github.com/rwth-iat/basyx-python-sdk@feature/http_api
+RUN pip install --no-cache-dir git+https://github.com/rwth-iat/basyx-python-sdk@main
 
 COPY ./app /app
 COPY ./nginx /etc/nginx/conf.d


### PR DESCRIPTION
Previously, the Dockerfile pointed to the 
development branch of the HTTP Server. 
This is outdated and the branch has been merged
with main. 
Therefore, we point the Dockerfile to the main 
branch.