### PR TITLE
app/main.py: fix storage_path

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,7 @@ from basyx.aas.adapter import aasx
 from basyx.aas.backend.local_file import LocalFileObjectStore
 from basyx.aas.adapter.http import WSGIApp
 
-storage_path = os.getenv("STORAGE_PATH", "storage")
+storage_path = os.getenv("STORAGE_PATH", "/storage")
 storage_type = os.getenv("STORAGE_TYPE", "LOCAL_FILE_READ_ONLY")
 base_path = os.getenv("API_BASE_PATH")
 


### PR DESCRIPTION
Currently running 
```
> docker run -p 8080:80 -v .\storage:/storage basyx-python-sdk-http-server
```
like recommended in the README does not work. This means, trying to run the container using the tutorial from the `README.md` leads to an error, due to a wrongly set default storage path if the environment variable `STORAGE_PATH` is not 
set. This fixes this issue by setting the default storage path to `/storage` rather than the prior relative path: `storage`. 
