### PR TITLE
Dockerfile: Change the path to the main Eclipse BaSyx Python SDK repsitory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# Ignore the default AAS storage directory
 storage/
+
+# Ignore PyCharm IDE configuration
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV NGINX_MAX_UPLOAD 1M
 ENV UWSGI_CHEAPER 0
 ENV UWSGI_PROCESSES 1
 
-RUN pip install --no-cache-dir git+https://github.com/rwth-iat/basyx-python-sdk@main
+RUN pip install --no-cache-dir git+https://github.com/eclipse-basyx/basyx-python-sdk@main
 
 COPY ./app /app
 COPY ./nginx /etc/nginx/conf.d


### PR DESCRIPTION
Previously, we used the `rwth-iat` fork to pull the SDK from, inside the docker file, due to the fact, that the `eclipse-basyx` repository, did not contain the necessary branch. Now that this is the case, it makes sense to always use the official repository.

This also fixes the dependency issues of missing dependencies, as they have been fixed in the main repository in [eclipse-basyx/basyx-python-sdk#313](https://github.com/eclipse-basyx/basyx-python-sdk/pull/313).

Fixes #8
Fixes #9