### PR TITLE
Adapt Dockerfile to new BaSyx-Python SDK repository structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV NGINX_MAX_UPLOAD 1M
 ENV UWSGI_CHEAPER 0
 ENV UWSGI_PROCESSES 1
 
-RUN pip install --no-cache-dir git+https://github.com/eclipse-basyx/basyx-python-sdk@main
+RUN pip install --no-cache-dir git+https://github.com/eclipse-basyx/basyx-python-sdk@main#subdirectory=sdk
 
 COPY ./app /app
 COPY ./nginx /etc/nginx/conf.d


### PR DESCRIPTION
Previously, the Eclipse BaSyx-Python SDK contained just the SDK module. With the recent refactoring of the SDK GitHub repository towards a monolithic structure, the SDK module moved into the `./sdk` subdirectory, see [basyx-python-sdk#317](https://github.com/eclipse-basyx/basyx-python-sdk/pull/317).

With the new repository structure, we obviously have to adapt the install path of the SDK in this Dockerfile, which has been done here.